### PR TITLE
make sure the placeholder text is updated if the attribute value is updated

### DIFF
--- a/lib/angular-placeholder.js
+++ b/lib/angular-placeholder.js
@@ -42,7 +42,16 @@ angular.module('ng.shims.placeholder', [])
 				hiddenClassName = 'ng-hide',
 				clone;
 
-			if (!text || !isInput) { return; }
+			attrs.$observe('placeholder', function(newValue) {
+				if (elem.hasClass(emptyClassName) && elem.val() === text) {
+					elem.val('');
+				}
+
+				text = newValue;
+				updateValue();
+			});
+
+			if (!isInput) { return; }
 
 			if (is_pwd) { setupPasswordPlaceholder(); }
 

--- a/test/unit/angular-placeholder-spec.js
+++ b/test/unit/angular-placeholder-spec.js
@@ -305,4 +305,32 @@ describe('placeholder', function() {
 			});
 		});
 	});
+
+	describe('updates when attribute updates', function() {
+		var elem;
+
+		beforeEach(function() {
+			scope.test = "value before";
+			scope.model = "";
+			elem = angular.element('<input type="text" placeholder="{{ test }}" ng-model="model" />');
+			$compile(elem)(scope);
+			scope.$digest();
+		});
+
+		it('should update when the attribute value is updated', function() {
+			expect(elem.val()).toBe('value before');
+			scope.test = "value after";
+			scope.$digest();
+			expect(elem.val()).toBe('value after');
+		});
+
+		it('should not update when the input field has text', function() {
+			expect(elem.val()).toBe('value before');
+			scope.model = "something";
+			scope.$digest();
+			scope.test = "value after";
+			scope.$digest();
+			expect(elem.val()).toBe('something');
+		});
+	});
 });


### PR DESCRIPTION
when using angular-translate to generate a placeholder text, the original, untranslated key, is never updated if the translations are loaded only after the input is rendered:

`<input placeholder="{{ 'something'|translate }}">`

This patch should also support the situation where the placeholder is absent, and added dynamically afterwards:

`<input translate translate-attr-placeholder="something">`
