### PR TITLE
Adding functionality to change placeholder text outside of angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ This directive is compatible with ngModel, ngDisabled, ngReadonly, ngRequired, n
 
 If you modify a shimmed input from outside of Angular, use the 'change' event to update the placeholder display. e.g. `elem.triggerHandler('change')`
 
+If you modify the placeholder attribute outside of angular, use the 'placeholder-change' event to update the placeholder text itself.  sytax as follows `elem.triggerHandler('placeholder-change', $('#myInput').attr('placeholder'))`
+
 Known Issues
 ------------
 * Ignores text input from drag and drop

--- a/lib/angular-placeholder.js
+++ b/lib/angular-placeholder.js
@@ -44,16 +44,16 @@ angular.module('ng.shims.placeholder', [])
 
 			if (!isInput) { return; }
 
-			function changePlaceholder(event, newValue) {
+			function changePlaceholder() {
+				text = attrs.placeholder;
                 if (elem.hasClass(emptyClassName) && elem.val() === text) {
                     elem.val('');
                 }
-                text = newValue;
 			    updateValue();
 			}
 				  
-			attrs.$observe('placeholder', function(newValue) {
-				elem.triggerHandler('placeholder-change', [newValue]);
+			attrs.$observe('placeholder', function() {
+				changePlaceholder();
 			});
 
 			if (is_pwd) { setupPasswordPlaceholder(); }
@@ -72,12 +72,10 @@ angular.module('ng.shims.placeholder', [])
 
 			// on blur, show placeholder if necessary
 			elem.bind('blur', updateValue);
-			//on custom 'placeholder-change' change the placeholder
-			elem.bind('placeholder-change', changePlaceholder);
 			// handler for model-less inputs to interact with non-angular code
 			// TODO: vs `$watch(function(){return elem.val()})`
 			if (!ngModel) {
-				elem.bind('change', updateValue);
+				elem.bind('change', changePlaceholder);
 			}
 
 			// model -> view

--- a/lib/angular-placeholder.js
+++ b/lib/angular-placeholder.js
@@ -44,13 +44,16 @@ angular.module('ng.shims.placeholder', [])
 
 			if (!isInput) { return; }
 
+			function changePlaceholder(event, newValue) {
+                if (elem.hasClass(emptyClassName) && elem.val() === text) {
+                    elem.val('');
+                }
+                text = newValue;
+			    updateValue();
+			}
+				  
 			attrs.$observe('placeholder', function(newValue) {
-				if (elem.hasClass(emptyClassName) && elem.val() === text) {
-					elem.val('');
-				}
-
-				text = newValue;
-				updateValue();
+				elem.triggerHandler('placeholder-change', [newValue]);
 			});
 
 			if (is_pwd) { setupPasswordPlaceholder(); }
@@ -69,7 +72,8 @@ angular.module('ng.shims.placeholder', [])
 
 			// on blur, show placeholder if necessary
 			elem.bind('blur', updateValue);
-
+			//on custom 'placeholder-change' change the placeholder
+			elem.bind('placeholder-change', changePlaceholder);
 			// handler for model-less inputs to interact with non-angular code
 			// TODO: vs `$watch(function(){return elem.val()})`
 			if (!ngModel) {


### PR DESCRIPTION
Ran into a situation, job related sadly, that there was legacy code that jquery was not cutting the mustard to get the placeholders polyfilled for ie8-9.  Your angular shim did the job but was missing a function to allow jquery to change the placeholder and update the ui through the directive.